### PR TITLE
Disable OSS by default on OpenBSD.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -53,6 +53,7 @@ ifeq ("$(UNAME)","OpenBSD")
   OS = FREEBSD
   SHARED = -shared
   SO_EXTENSION = so
+  NO_OSS = 1
   $(warning OS type "$(UNAME)" not officially supported.')
 endif
 ifneq ("$(filter GNU/kFreeBSD kfreebsd,$(UNAME))","")


### PR DESCRIPTION
OpenBSD never used OSS for mupen64plus and is likely to remove libossaudio.
