### PR TITLE
bug workaround (volume does not follow system volume on jolla phone)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -299,6 +299,8 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
         ConfigSaveSection("Audio-SDL");
 
 #ifdef USE_AUDIORESOURCE
+    setenv("PULSE_PROP_media.role", "x-maemo", 1);
+
     l_audioresource = audioresource_init(AUDIO_RESOURCE_GAME, on_audioresource_acquired, NULL);
 
     audioresource_acquire(l_audioresource);


### PR DESCRIPTION
https://bugs.maemo.org/show_bug.cgi?id=7159

with this change mupen64plus volume follows the system volume (can be changed via +/- buttons) previously mupen64plus always ran with maximum volume on the jolla phone.