### PR TITLE
Update to Visual Studio 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 1.0.{build}
+
+configuration:
+  - Release
+platform:
+  - x86
+  - x64
+
+before_build:
+- cmd: >-
+    git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ../mupen64plus-win32-deps
+    git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
+build:
+  project: projects/VisualStudio2015/mupen64plus-audio-sdl.vcxproj
+  verbosity: minimal

--- a/projects/VisualStudio2015/mupen64plus-audio-sdl.vcxproj
+++ b/projects/VisualStudio2015/mupen64plus-audio-sdl.vcxproj
@@ -28,23 +28,23 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
I didn't switch this to SDL2 because audio-sdl is currently incompatible with SDL2.0.6 on Windows.

SDL2.0.6 switched the audio backend on Windows to WASAPI. With this change, it forces the output format to AUDIO_F32 (floating point samples), but audio-sdl assumes AUDIO_S16 (integer samples). The result is no sound.

audio-sdl will need to be fixed up to detect ```if hardware_spec->format == AUDIO_F32``` and convert the samples accordingly