### PR TITLE
Refactorings

### DIFF
--- a/projects/VisualStudio2013/mupen64plus-audio-sdl.vcxproj
+++ b/projects/VisualStudio2013/mupen64plus-audio-sdl.vcxproj
@@ -165,12 +165,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\circular_buffer.c" />
     <ClCompile Include="..\..\src\main.c" />
     <ClCompile Include="..\..\src\osal_dynamiclib_win32.c" />
+    <ClCompile Include="..\..\src\sdl_backend.c" />
+    <ClCompile Include="..\..\src\resamplers\resamplers.c" />
+    <ClCompile Include="..\..\src\resamplers\trivial.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\circular_buffer.h" />
     <ClInclude Include="..\..\src\main.h" />
     <ClInclude Include="..\..\src\osal_dynamiclib.h" />
+    <ClInclude Include="..\..\src\sdl_backend.h" />
+    <ClInclude Include="..\..\src\resamplers\resamplers.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -296,6 +296,7 @@ OBJDIR = _obj$(POSTFIX)
 
 # list of source files to compile
 SOURCE = \
+	$(SRCDIR)/circular_buffer.c \
 	$(SRCDIR)/main.c \
 	$(SRCDIR)/volume.c \
 	$(SRCDIR)/resamplers/resamplers.c \

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -297,12 +297,21 @@ OBJDIR = _obj$(POSTFIX)
 # list of source files to compile
 SOURCE = \
 	$(SRCDIR)/main.c \
-	$(SRCDIR)/volume.c
+	$(SRCDIR)/volume.c \
+	$(SRCDIR)/resamplers/resamplers.c \
+	$(SRCDIR)/resamplers/trivial.c
 
 ifeq ($(OS),MINGW)
 SOURCE += $(SRCDIR)/osal_dynamiclib_win32.c
 else
 SOURCE += $(SRCDIR)/osal_dynamiclib_unix.c
+endif
+
+ifneq ($(NO_SPEEX), 1)
+  SOURCE += $(SRCDIR)/resamplers/speex.c
+endif
+ifneq ($(NO_SRC), 1)
+  SOURCE += $(SRCDIR)/resamplers/src.c
 endif
 
 # generate a list of object files build, make a temporary directory for them

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -298,6 +298,7 @@ OBJDIR = _obj$(POSTFIX)
 SOURCE = \
 	$(SRCDIR)/circular_buffer.c \
 	$(SRCDIR)/main.c \
+	$(SRCDIR)/sdl_backend.c \
 	$(SRCDIR)/volume.c \
 	$(SRCDIR)/resamplers/resamplers.c \
 	$(SRCDIR)/resamplers/trivial.c

--- a/src/circular_buffer.c
+++ b/src/circular_buffer.c
@@ -1,0 +1,83 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-ui-console - circular_buffer.c                            *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2015 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "circular_buffer.h"
+
+
+int init_cbuff(struct circular_buffer* cbuff, size_t capacity)
+{
+    void* data = malloc(capacity);
+
+    if (data == NULL)
+    {
+        return -1;
+    }
+
+    cbuff->data = data;
+    cbuff->size = capacity;
+    cbuff->head = 0;
+
+    return 0;
+}
+
+void release_cbuff(struct circular_buffer* cbuff)
+{
+    free(cbuff->data);
+    memset(cbuff, 0, sizeof(*cbuff));
+}
+
+
+void* cbuff_head(const struct circular_buffer* cbuff, size_t* available)
+{
+    assert(cbuff->head <= cbuff->size);
+
+    *available = cbuff->size - cbuff->head;
+    return (void*)((char*)cbuff->data + cbuff->head);
+}
+
+
+void* cbuff_tail(const struct circular_buffer* cbuff, size_t* available)
+{
+    *available = cbuff->head;
+    return cbuff->data;
+}
+
+
+void produce_cbuff_data(struct circular_buffer* cbuff, size_t amount)
+{
+    assert(cbuff->head + amount <= cbuff->size);
+
+    cbuff->head += amount;
+}
+
+
+void consume_cbuff_data(struct circular_buffer* cbuff, size_t amount)
+{
+    assert(cbuff->head >= amount);
+
+    memmove(cbuff->data, cbuff->data + amount, cbuff->head - amount);
+    cbuff->head -= amount;
+}
+

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -1,0 +1,46 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-ui-console - circular_buffer.h                            *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2015 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_CIRCULAR_BUFFER_H
+#define M64P_CIRCULAR_BUFFER_H
+
+#include <stddef.h>
+
+struct circular_buffer
+{
+    void* data;
+    size_t size;
+    size_t head;
+};
+
+int init_cbuff(struct circular_buffer* cbuff, size_t capacity);
+
+void release_cbuff(struct circular_buffer* cbuff);
+
+void* cbuff_head(const struct circular_buffer* cbuff, size_t* available);
+
+void* cbuff_tail(const struct circular_buffer* cbuff, size_t* available);
+
+void produce_cbuff_data(struct circular_buffer* cbuff, size_t amount);
+
+void consume_cbuff_data(struct circular_buffer* cbuff, size_t amount);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -202,10 +202,10 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
                                    void (*DebugCallback)(void *, int, const char *))
 {
     ptr_CoreGetAPIVersions CoreAPIVersionFunc;
-    
+
     int ConfigAPIVersion, DebugAPIVersion, VidextAPIVersion, bSaveConfig;
     float fConfigParamsVersion = 0.0f;
-    
+
     if (l_PluginInit)
         return M64ERR_ALREADY_INIT;
 
@@ -220,7 +220,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
         DebugMessage(M64MSG_ERROR, "Core emulator broken; no CoreAPIVersionFunc() function found.");
         return M64ERR_INCOMPATIBLE;
     }
-    
+
     (*CoreAPIVersionFunc)(&ConfigAPIVersion, &DebugAPIVersion, &VidextAPIVersion, NULL);
     if ((ConfigAPIVersion & 0xffff0000) != (CONFIG_API_VERSION & 0xffff0000))
     {
@@ -362,7 +362,7 @@ EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *Plugi
 
     if (APIVersion != NULL)
         *APIVersion = AUDIO_PLUGIN_API_VERSION;
-    
+
     if (PluginNamePtr != NULL)
         *PluginNamePtr = "Mupen64Plus SDL Audio Plugin";
 
@@ -370,7 +370,7 @@ EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *Plugi
     {
         *Capabilities = 0;
     }
-                    
+
     return M64ERR_SUCCESS;
 }
 
@@ -720,7 +720,7 @@ static void InitializeAudio(int freq)
         SDL_PauseAudio(1);
         SDL_CloseAudio();
     }
-    else 
+    else
     {
         DebugMessage(M64MSG_VERBOSE, "InitializeAudio(): Initializing SDL Audio");
         DebugMessage(M64MSG_VERBOSE, "Primary buffer: %i output samples.", PrimaryBufferSize);
@@ -740,9 +740,9 @@ static void InitializeAudio(int freq)
     if(freq < 11025) OutputFreq = 11025;
     else if(freq < 22050) OutputFreq = 22050;
     else OutputFreq = 44100;
-    
+
     desired->freq = OutputFreq;
-    
+
     DebugMessage(M64MSG_VERBOSE, "Requesting frequency: %iHz.", desired->freq);
     /* 16-bit signed audio */
     desired->format=AUDIO_S16SYS;
@@ -826,7 +826,7 @@ EXPORT void CALL RomClosed( void )
    if (critical_failure == 1)
        return;
     DebugMessage(M64MSG_VERBOSE, "Cleaning up SDL sound plugin...");
-    
+
     // Shut down SDL Audio output
     SDL_PauseAudio(1);
     SDL_CloseAudio();
@@ -1026,7 +1026,7 @@ EXPORT void CALL VolumeSetLevel(int level)
     //if muted, unmute first
     VolIsMuted = 0;
 
-    // adjust volume 
+    // adjust volume
     VolPercent = level;
     if (VolPercent < 0)
         VolPercent = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -48,3 +48,4 @@ extern ptr_ConfigGetParamFloat    ConfigGetParamFloat;
 extern ptr_ConfigGetParamBool     ConfigGetParamBool;
 extern ptr_ConfigGetParamString   ConfigGetParamString;
 
+void DebugMessage(int level, const char *message, ...);

--- a/src/main.h
+++ b/src/main.h
@@ -22,12 +22,22 @@
 /* version info */
 #include "m64p_config.h"
 
-#define SDL_AUDIO_PLUGIN_VERSION 0x020500
-#define AUDIO_PLUGIN_API_VERSION 0x020000
-#define CONFIG_API_VERSION       0x020100
-#define CONFIG_PARAM_VERSION     1.00
+#include <stddef.h>
 
-#define VERSION_PRINTF_SPLIT(x) (((x) >> 16) & 0xffff), (((x) >> 8) & 0xff), ((x) & 0xff)
+struct resampler_interface;
+
+/* volume mixer types */
+enum {
+    VOLUME_TYPE_SDL = 1,
+    VOLUME_TYPE_OSS = 2,
+};
+
+void SetPlaybackVolume(void);
+
+size_t ResampleAndMix(void* resampler, const struct resampler_interface* iresampler,
+        void* mix_buffer,
+        const void* src, size_t src_size, unsigned int src_freq,
+        void* dst, size_t dst_size, unsigned int dst_freq);
 
 /* declarations of pointers to Core config functions */
 extern ptr_ConfigListSections     ConfigListSections;

--- a/src/resamplers/resamplers.c
+++ b/src/resamplers/resamplers.c
@@ -1,0 +1,78 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-audio-sdl - resamplers.c                                  *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "resamplers.h"
+
+#include "main.h"
+
+#include "m64p_types.h"
+
+#include <string.h>
+
+
+extern const struct resampler_interface g_trivial_iresampler;
+#ifdef USE_SPEEX
+extern const struct resampler_interface g_speex_iresampler;
+#endif
+#ifdef USE_SRC
+extern const struct resampler_interface g_src_iresampler;
+#endif
+
+
+#define ARRAY_SIZE(x) sizeof((x)) / sizeof((x)[0])
+
+const struct resampler_interface* get_iresampler(const char* resampler_id, void** resampler)
+{
+    size_t i;
+
+    static const struct {
+        const struct resampler_interface* iresampler;
+        const char* cmp_str;
+    } resamplers[] = {
+        { &g_trivial_iresampler, "trivial" },
+#ifdef USE_SPEEX
+        { &g_speex_iresampler, "speex-" },
+#endif
+#ifdef USE_SRC
+        { &g_src_iresampler, "src-" }
+#endif
+    };
+
+    /* search matching resampler */
+    for(i = 0; i < ARRAY_SIZE(resamplers); ++i) {
+        if (strncmp(resampler_id, resamplers[i].cmp_str, strlen(resamplers[i].cmp_str)) == 0) {
+            DebugMessage(M64MSG_INFO, "Using resampler %s", resamplers[i].iresampler->name);
+            break;
+        }
+    }
+
+    /* handle not found case */
+    if (i >= ARRAY_SIZE(resamplers)) {
+        i = 0;
+
+        DebugMessage(M64MSG_WARNING, "Could not find RESAMPLE configuration %s; use %s resampler",
+            resampler_id, resamplers[i].iresampler->name);
+    }
+
+    /* instanciate resampler */
+    *resampler = resamplers[i].iresampler->init_from_id(resampler_id);
+    return resamplers[i].iresampler;
+}

--- a/src/resamplers/resamplers.h
+++ b/src/resamplers/resamplers.h
@@ -1,0 +1,51 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-audio-sdl - resamplers.h                                  *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_RESAMPLERS_RESAMPLERS_H
+#define M64P_RESAMPLERS_RESAMPLERS_H
+
+#include <stddef.h>
+
+struct resampler_interface
+{
+    const char* name;
+
+    void* (*init_from_id)(const char* resampler_id);
+
+    void (*release)(void* resampler);
+
+    size_t (*resample)(void* resampler,
+                       const void* src, size_t src_size, unsigned int src_freq,
+                       void* dst, size_t dst_size, unsigned int dst_freq);
+};
+
+const struct resampler_interface* get_iresampler(const char* resampler_id, void** resampler);
+
+/* default resampler */
+#if defined(USE_SPEEX)
+    #define DEFAULT_RESAMPLER "speex-fixed-4"
+#elif defined(USE_SRC)
+    #define DEFAULT_RESAMPLER "src-sinc-medium-quality"
+#else
+    #define DEFAULT_RESAMPLER "trivial"
+#endif
+
+#endif

--- a/src/resamplers/speex.c
+++ b/src/resamplers/speex.c
@@ -1,0 +1,126 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-sdl-audio - speex.c                                       *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "resamplers/resamplers.h"
+#include "main.h"
+
+#include <speex/speex_resampler.h>
+
+#include "m64p_types.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define ARRAY_SIZE(x) sizeof((x)) / sizeof((x)[0])
+
+/* assume 2x16bit interleaved channels */
+enum { BYTES_PER_SAMPLE = 4 };
+
+
+
+static void* speex_init_from_id(const char* resampler_id)
+{
+    size_t i;
+    int error;
+    static const char *types[] =
+    {
+        "speex-fixed-0",
+        "speex-fixed-1",
+        "speex-fixed-2",
+        "speex-fixed-3",
+        "speex-fixed-4",
+        "speex-fixed-5",
+        "speex-fixed-6",
+        "speex-fixed-7",
+        "speex-fixed-8",
+        "speex-fixed-9",
+        "speex-fixed-10",
+    };
+
+    /* select resampler configuration */
+    for (i = 0; i < ARRAY_SIZE(types); ++i) {
+        if (strcmp(types[i], resampler_id) == 0) {
+            break;
+        }
+    }
+
+    /* handle unknown configuration */
+    if (i >= ARRAY_SIZE(types)) {
+        i = 4;
+
+        DebugMessage(M64MSG_WARNING,
+            "Unknown RESAMPLE configuration %s; use %s resampler",
+            resampler_id, types[i]);
+    }
+
+    /* init speex object with dummy frequencies (will be set later) */
+    SpeexResamplerState* spx_state =  speex_resampler_init(2, 44100, 44100, (int)i,  &error);
+
+    if (error != RESAMPLER_ERR_SUCCESS) {
+        DebugMessage(M64MSG_ERROR, "Speex error: %s", speex_resampler_strerror(error));
+    }
+
+    return spx_state;
+}
+
+static void speex_release(void* resampler)
+{
+    SpeexResamplerState* spx_state = (SpeexResamplerState*)resampler;
+
+    if (spx_state == NULL) {
+        return;
+    }
+
+    speex_resampler_destroy(spx_state);
+}
+
+static size_t speex_resample(void* resampler,
+                             const void* src, size_t src_size, unsigned int src_freq,
+                             void* dst, size_t dst_size, unsigned int dst_freq)
+{
+    SpeexResamplerState* spx_state = (SpeexResamplerState*)resampler;
+
+    /* update resampling rates */
+    speex_resampler_set_rate(spx_state, src_freq, dst_freq);
+
+    /* perform resampling */
+    spx_uint32_t in_len = src_size / BYTES_PER_SAMPLE;
+    spx_uint32_t out_len = dst_size / BYTES_PER_SAMPLE;
+    int error = speex_resampler_process_interleaved_int(spx_state, (const spx_int16_t *)src, &in_len, (spx_int16_t *)dst, &out_len);
+
+    /* in case of error, display error, zero output buffer and discard input buffer */
+    if (error != RESAMPLER_ERR_SUCCESS)
+    {
+        DebugMessage(M64MSG_ERROR, "Speex error: %s", speex_resampler_strerror(error));
+        memset(dst, 0, dst_size);
+        return src_size;
+    }
+
+    return in_len * BYTES_PER_SAMPLE;
+}
+
+
+const struct resampler_interface g_speex_iresampler = {
+    "speex",
+    speex_init_from_id,
+    speex_release,
+    speex_resample
+};

--- a/src/resamplers/src.c
+++ b/src/resamplers/src.c
@@ -1,0 +1,202 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-sdl-audio - src.c                                         *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "resamplers/resamplers.h"
+#include "main.h"
+
+#include <samplerate.h>
+
+#include "m64p_types.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARRAY_SIZE(x) sizeof((x)) / sizeof((x)[0])
+
+struct fbuffer
+{
+    float* data;
+    size_t size;
+};
+
+static void grow_fbuffer(struct fbuffer* fbuffer, size_t new_size)
+{
+    if (fbuffer->size < new_size) {
+        fbuffer->data = realloc(fbuffer->data, new_size);
+        fbuffer->size = new_size;
+    }
+}
+
+static void free_fbuffer(struct fbuffer* fbuffer)
+{
+    free(fbuffer->data);
+    fbuffer->data = NULL;
+    fbuffer->size = 0;
+}
+
+
+
+struct src_resampler
+{
+    SRC_STATE* state;
+
+    /* 2 intermediate buffers are needed for float/int conversion */
+    struct fbuffer fbuffers[2];
+};
+
+static void* src_init_from_id(const char* resampler_id)
+{
+    size_t i;
+    int error = 0;
+
+    static const struct {
+        const char* name;
+        int converter_type;
+    } types[] =
+    {
+        { "src-sinc-best-quality", SRC_SINC_BEST_QUALITY },
+        { "src-sinc-medium-quality", SRC_SINC_MEDIUM_QUALITY },
+        { "src-sinc-fastest", SRC_SINC_FASTEST },
+        { "src-zero-order-hold", SRC_ZERO_ORDER_HOLD },
+        { "src-linear",  SRC_LINEAR }
+    };
+
+    /* select resampler configuration */
+    for (i = 0; i < ARRAY_SIZE(types); ++i) {
+        if (strcmp(types[i].name, resampler_id) == 0) {
+            break;
+        }
+    }
+
+    /* handle unknown configuration */
+    if (i >= ARRAY_SIZE(types)) {
+        i = 1;
+
+        DebugMessage(M64MSG_WARNING,
+            "Unknown RESAMPLE configuration %s; use %s resampler",
+            resampler_id, types[i].name);
+    }
+
+    /* init src resampler */
+    struct src_resampler* src_resampler = malloc(sizeof(*src_resampler));
+    if (src_resampler == NULL) {
+        DebugMessage(M64MSG_ERROR, "Failed to allocate memory for SRC resampler");
+        return NULL;
+    }
+
+    /* lazy-alloc of fbuffers */
+    memset(src_resampler, 0, sizeof(*src_resampler));
+
+    src_resampler->state = src_new(types[i].converter_type, 2, &error);
+    if (error != 0) {
+        DebugMessage(M64MSG_ERROR, "SRC error: %s", src_strerror(error));
+        free(src_resampler);
+        return NULL;
+    }
+
+    return src_resampler;
+}
+
+static void src_release(void* resampler)
+{
+    size_t i;
+
+    struct src_resampler* src_resampler = (struct src_resampler*)resampler;
+
+    if (src_resampler == NULL)
+        return;
+
+    src_delete(src_resampler->state);
+
+    for(i = 0; i < 2; ++i) {
+        free_fbuffer(&src_resampler->fbuffers[i]);
+    }
+}
+
+static size_t src_resample(void* resampler,
+                           const void* src, size_t src_size, unsigned int src_freq,
+                           void* dst, size_t dst_size, unsigned int dst_freq)
+{
+    struct src_resampler* src_resampler = (struct src_resampler*)resampler;
+
+    /* High quality resamplers needs more input than what
+     * the sample rate ratio would indicate to work properly, hence the src/dst>1 ratio
+     *
+     * Limit src_size to avoid too much short-float-short conversion time
+     */
+    if (src_size > dst_size * 5 / 2) {
+        src_size = dst_size * 5 / 2;
+    }
+
+    /* grow float buffers if necessary */
+    if (src_size > 0) {
+        grow_fbuffer(&src_resampler->fbuffers[0], src_size*2);
+    }
+    if (dst_size > 0) {
+        grow_fbuffer(&src_resampler->fbuffers[1], dst_size*2);
+    }
+
+    memset(src_resampler->fbuffers[0].data, 0, src_resampler->fbuffers[0].size);
+    memset(src_resampler->fbuffers[1].data, 0, src_resampler->fbuffers[1].size);
+
+    src_short_to_float_array((short*)src, src_resampler->fbuffers[0].data, src_size/2);
+
+    /* perform resampling */
+    SRC_DATA src_data;
+
+    src_data.data_in = src_resampler->fbuffers[0].data;
+    src_data.input_frames = src_size/4;
+
+    src_data.data_out = src_resampler->fbuffers[1].data;
+    src_data.output_frames = dst_size/4;
+
+    src_data.src_ratio = (float)dst_freq / src_freq;
+    src_data.end_of_input = 0;
+
+    int error = src_process(src_resampler->state, &src_data);
+
+    /* in case of error, display error, zero output buffer and discard input buffer */
+    if (error)
+    {
+        DebugMessage(M64MSG_ERROR, "SRC error: %s", src_strerror(error));
+        memset(dst, 0, dst_size);
+        return src_size;
+    }
+
+    if (dst_size != src_data.output_frames_gen*4) {
+        DebugMessage(M64MSG_WARNING, "dst_size = %u != output_frames_gen*4 = %u",
+                dst_size, src_data.output_frames_gen*4);
+    }
+
+    src_float_to_short_array(src_resampler->fbuffers[1].data, (short*)dst, src_data.output_frames_gen*2);
+    memset((char*)dst + src_data.output_frames_gen*4, 0, dst_size - src_data.output_frames_gen*4);
+
+    return src_data.input_frames_used * 4;
+}
+
+
+const struct resampler_interface g_src_iresampler = {
+    "src",
+    src_init_from_id,
+    src_release,
+    src_resample
+};

--- a/src/resamplers/trivial.c
+++ b/src/resamplers/trivial.c
@@ -1,0 +1,83 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-sdl-audio - trivial.c                                     *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "resamplers/resamplers.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+static void* trivial_init_from_id(const char* resampler_id)
+{
+    /* nothing to do */
+    return NULL;
+}
+
+static void trivial_release(void* resampler)
+{
+    /* nothing to do */
+}
+
+static size_t trivial_resample(void* resampler,
+                               const void* src, size_t src_size, unsigned int src_freq,
+                               void* dst, size_t dst_size, unsigned int dst_freq)
+{
+    enum { BYTES_PER_SAMPLE = 4 };
+    size_t i, j;
+
+    if (dst_freq >= src_freq) {
+        const int dpos = 2*src_freq;
+        const int dneg = dpos - 2*dst_freq;
+
+        j = 0;
+        int criteria = dpos - dst_freq;
+
+        for (i = 0; i < dst_size/BYTES_PER_SAMPLE; ++i) {
+
+            ((uint32_t*)dst)[i] = ((const uint32_t*)src)[j];
+
+            if (criteria >= 0) {
+                ++j;
+                criteria += dneg;
+            }
+            else {
+                criteria += dpos;
+            }
+        }
+    }
+    else {
+        /* Can happen when speed_factor > 1 */
+        for (i = 0; i < dst_size/BYTES_PER_SAMPLE; ++i) {
+
+            j = i * src_freq / dst_freq;
+            ((uint32_t*)dst)[i] = ((const uint32_t*)src)[j];
+        }
+    }
+
+    return j * 4;
+}
+
+
+const struct resampler_interface g_trivial_iresampler = {
+    "trivial",
+    trivial_init_from_id,
+    trivial_release,
+    trivial_resample
+};

--- a/src/sdl_backend.c
+++ b/src/sdl_backend.c
@@ -1,0 +1,432 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-sdl-audio - sdl_backend.c                                 *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <SDL.h>
+#include <SDL_audio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "circular_buffer.h"
+#include "main.h"
+#include "resamplers/resamplers.h"
+
+#define M64P_PLUGIN_PROTOTYPES 1
+#include "m64p_common.h"
+#include "m64p_config.h"
+#include "m64p_types.h"
+
+/* number of bytes per sample */
+#define N64_SAMPLE_BYTES 4
+#define SDL_SAMPLE_BYTES 4
+
+struct sdl_backend
+{
+    m64p_handle config;
+
+    struct circular_buffer primary_buffer;
+
+    /* Primary buffer size (in output samples) */
+    size_t primary_buffer_size;
+
+    /* Primary buffer fullness target (in output samples) */
+    size_t target;
+
+    /* Secondary buffer size (in output samples) */
+    size_t secondary_buffer_size;
+
+    /* Mixing buffer used for volume control */
+    unsigned char* mix_buffer;
+
+    unsigned int last_cb_time;
+    unsigned int input_frequency;
+    unsigned int output_frequency;
+    unsigned int speed_factor;
+
+    unsigned int swap_channels;
+
+    unsigned int audio_sync;
+
+    unsigned int paused_for_sync;
+
+    unsigned int underrun_count;
+
+    unsigned int error;
+
+    /* Resampler */
+    void* resampler;
+    const struct resampler_interface* iresampler;
+};
+
+static void my_audio_callback(void* userdata, unsigned char* stream, int len)
+{
+    struct sdl_backend* sdl_backend = (struct sdl_backend*)userdata;
+
+    /* mark the time, for synchronization on the input side */
+    sdl_backend->last_cb_time = SDL_GetTicks();
+
+    unsigned int newsamplerate = sdl_backend->output_frequency * 100 / sdl_backend->speed_factor;
+    unsigned int oldsamplerate = sdl_backend->input_frequency;
+    size_t needed = (len * oldsamplerate) / newsamplerate;
+    size_t available;
+    size_t consumed;
+
+    const void* src = cbuff_tail(&sdl_backend->primary_buffer, &available);
+    if ((available > 0) && (available >= needed))
+    {
+        consumed = ResampleAndMix(sdl_backend->resampler, sdl_backend->iresampler,
+                sdl_backend->mix_buffer,
+                src, available, oldsamplerate,
+                stream, len, newsamplerate);
+
+        consume_cbuff_data(&sdl_backend->primary_buffer, consumed);
+    }
+    else
+    {
+        ++sdl_backend->underrun_count;
+        memset(stream , 0, len);
+    }
+}
+
+static size_t new_primary_buffer_size(const struct sdl_backend* sdl_backend)
+{
+    return N64_SAMPLE_BYTES * ((uint64_t)sdl_backend->primary_buffer_size * sdl_backend->input_frequency * sdl_backend->speed_factor) /
+        (sdl_backend->output_frequency * 100);
+}
+
+static void resize_primary_buffer(struct circular_buffer* cbuff, size_t new_size)
+{
+    /* only grows the buffer */
+    if (new_size > cbuff->size) {
+        SDL_LockAudio();
+        cbuff->data = realloc(cbuff->data, new_size);
+        memset(cbuff->data + cbuff->size, 0, new_size - cbuff->size);
+        SDL_UnlockAudio();
+        cbuff->size = new_size;
+    }
+}
+
+static unsigned int select_output_frequency(unsigned int input_frequency)
+{
+    if (input_frequency <= 11025) { return 11025; }
+    else if (input_frequency <= 22050) { return 22050; }
+    else { return 44100; }
+}
+
+static void sdl_init_audio_device(struct sdl_backend* sdl_backend)
+{
+    SDL_AudioSpec desired, obtained;
+
+    sdl_backend->error = 0;
+
+    if (SDL_WasInit(SDL_INIT_AUDIO|SDL_INIT_TIMER) == (SDL_INIT_AUDIO|SDL_INIT_TIMER) )
+    {
+        DebugMessage(M64MSG_VERBOSE, "sdl_init_audio_device(): SDL Audio sub-system already initialized.");
+
+        SDL_PauseAudio(1);
+        SDL_CloseAudio();
+    }
+    else
+    {
+        if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_TIMER) < 0)
+        {
+            DebugMessage(M64MSG_ERROR, "Failed to initialize SDL audio subsystem.");
+            sdl_backend->error = 1;
+            return;
+        }
+    }
+
+    sdl_backend->paused_for_sync = 1;
+
+    /* reload these because they gets re-assigned from SDL data below, and sdl_init_audio_device can be called more than once */
+    sdl_backend->primary_buffer_size = ConfigGetParamInt(sdl_backend->config, "PRIMARY_BUFFER_SIZE");
+    sdl_backend->target = ConfigGetParamInt(sdl_backend->config, "PRIMARY_BUFFER_TARGET");
+    sdl_backend->secondary_buffer_size = ConfigGetParamInt(sdl_backend->config, "SECONDARY_BUFFER_SIZE");
+
+    DebugMessage(M64MSG_INFO,    "Initializing SDL audio subsystem...");
+    DebugMessage(M64MSG_VERBOSE, "Primary buffer: %i output samples.", sdl_backend->primary_buffer_size);
+    DebugMessage(M64MSG_VERBOSE, "Primary target fullness: %i output samples.", sdl_backend->target);
+    DebugMessage(M64MSG_VERBOSE, "Secondary buffer: %i output samples.", sdl_backend->secondary_buffer_size);
+
+    memset(&desired, 0, sizeof(desired));
+    desired.freq = select_output_frequency(sdl_backend->input_frequency);
+    desired.format = AUDIO_S16SYS;
+    desired.channels = 2;
+    desired.samples = sdl_backend->secondary_buffer_size;
+    desired.callback = my_audio_callback;
+    desired.userdata = sdl_backend;
+
+    DebugMessage(M64MSG_VERBOSE, "Requesting frequency: %iHz.", desired.freq);
+    DebugMessage(M64MSG_VERBOSE, "Requesting format: %i.", desired.format);
+
+    /* Open the audio device */
+    if (SDL_OpenAudio(&desired, &obtained) < 0)
+    {
+        DebugMessage(M64MSG_ERROR, "Couldn't open audio: %s", SDL_GetError());
+        sdl_backend->error = 1;
+        return;
+    }
+    if (desired.format != obtained.format)
+    {
+        DebugMessage(M64MSG_WARNING, "Obtained audio format differs from requested.");
+    }
+    if (desired.freq != obtained.freq)
+    {
+        DebugMessage(M64MSG_WARNING, "Obtained frequency differs from requested.");
+    }
+
+    /* adjust some variables given the obtained audio spec */
+    sdl_backend->output_frequency = obtained.freq;
+    sdl_backend->secondary_buffer_size = obtained.samples;
+
+    if (sdl_backend->target < sdl_backend->secondary_buffer_size)
+        sdl_backend->target = sdl_backend->secondary_buffer_size;
+
+    if (sdl_backend->primary_buffer_size < sdl_backend->target)
+        sdl_backend->primary_buffer_size = sdl_backend->target;
+    if (sdl_backend->primary_buffer_size < sdl_backend->secondary_buffer_size * 2)
+        sdl_backend->primary_buffer_size = sdl_backend->secondary_buffer_size * 2;
+
+    /* allocate memory for audio buffers */
+    resize_primary_buffer(&sdl_backend->primary_buffer, new_primary_buffer_size(sdl_backend));
+    sdl_backend->mix_buffer = realloc(sdl_backend->mix_buffer, sdl_backend->secondary_buffer_size * SDL_SAMPLE_BYTES);
+
+    /* preset the last callback time */
+    if (sdl_backend->last_cb_time == 0) {
+        sdl_backend->last_cb_time = SDL_GetTicks();
+    }
+
+    DebugMessage(M64MSG_VERBOSE, "Frequency: %i", obtained.freq);
+    DebugMessage(M64MSG_VERBOSE, "Format: %i", obtained.format);
+    DebugMessage(M64MSG_VERBOSE, "Channels: %i", obtained.channels);
+    DebugMessage(M64MSG_VERBOSE, "Silence: %i", obtained.silence);
+    DebugMessage(M64MSG_VERBOSE, "Samples: %i", obtained.samples);
+    DebugMessage(M64MSG_VERBOSE, "Size: %i", obtained.size);
+
+    /* set playback volume */
+    SetPlaybackVolume();
+}
+
+static void release_audio_device(struct sdl_backend* sdl_backend)
+{
+    if (SDL_WasInit(SDL_INIT_AUDIO) != 0) {
+        SDL_PauseAudio(1);
+        SDL_CloseAudio();
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
+
+    if (SDL_WasInit(SDL_INIT_TIMER) != 0) {
+        SDL_QuitSubSystem(SDL_INIT_TIMER);
+    }
+}
+
+
+static struct sdl_backend* init_sdl_backend(m64p_handle config,
+                                            unsigned int default_frequency,
+                                            unsigned int swap_channels,
+                                            unsigned int audio_sync,
+                                            const char* resampler_id)
+{
+    /* allocate memory for sdl_backend */
+    struct sdl_backend* sdl_backend = malloc(sizeof(*sdl_backend));
+    if (sdl_backend == NULL) {
+        return NULL;
+    }
+
+    /* reset sdl_backend */
+    memset(sdl_backend, 0, sizeof(*sdl_backend));
+
+    /* instanciate resampler */
+    void* resampler = NULL;
+    const struct resampler_interface* iresampler = get_iresampler(resampler_id, &resampler);
+    if (iresampler == NULL) {
+        free(sdl_backend);
+        return NULL;
+    }
+
+    sdl_backend->config = config;
+    sdl_backend->input_frequency = default_frequency;
+    sdl_backend->swap_channels = swap_channels;
+    sdl_backend->audio_sync = audio_sync;
+    sdl_backend->paused_for_sync = 1;
+    sdl_backend->speed_factor = 100;
+    sdl_backend->resampler = resampler;
+    sdl_backend->iresampler = iresampler;
+
+    sdl_init_audio_device(sdl_backend);
+
+    return sdl_backend;
+}
+
+struct sdl_backend* init_sdl_backend_from_config(m64p_handle config)
+{
+    unsigned int default_frequency = ConfigGetParamInt(config, "DEFAULT_FREQUENCY");
+    unsigned int swap_channels = ConfigGetParamBool(config, "SWAP_CHANNELS");
+    unsigned int audio_sync = ConfigGetParamBool(config, "AUDIO_SYNC");
+    const char* resampler_id = ConfigGetParamString(config, "RESAMPLE");
+
+    return init_sdl_backend(config,
+            default_frequency,
+            swap_channels,
+            audio_sync,
+            resampler_id);
+}
+
+
+void release_sdl_backend(struct sdl_backend* sdl_backend)
+{
+    if (sdl_backend == NULL) {
+        return;
+    }
+
+    if (sdl_backend->error == 0) {
+        release_audio_device(sdl_backend);
+    }
+
+    /* release primary buffer */
+    release_cbuff(&sdl_backend->primary_buffer);
+
+    /* release mix buffer */
+    free(sdl_backend->mix_buffer);
+
+    /* release resampler */
+    sdl_backend->iresampler->release(sdl_backend->resampler);
+
+    /* release sdl backend */
+    free(sdl_backend);
+}
+
+void sdl_set_format(struct sdl_backend* sdl_backend, unsigned int frequency, unsigned int bits)
+{
+    if (sdl_backend->error != 0)
+        return;
+
+    /* XXX: assume 16-bit samples */
+    if (bits != 16) {
+        DebugMessage(M64MSG_ERROR, "Incoming samples are not 16 bits (%d)", bits);
+    }
+
+    sdl_backend->input_frequency = frequency;
+    sdl_init_audio_device(sdl_backend);
+}
+
+
+void sdl_push_samples(struct sdl_backend* sdl_backend, const void* src, size_t size)
+{
+    size_t available;
+
+    if (sdl_backend->error != 0)
+        return;
+
+    void* dst = cbuff_head(&sdl_backend->primary_buffer, &available);
+
+    if (size <= available)
+    {
+        SDL_LockAudio();
+
+        if (sdl_backend->swap_channels) {
+            memcpy(dst, src, size);
+        }
+        else {
+            size_t i;
+            for (i = 0 ; i < size ; i += 4 )
+            {
+                memcpy(dst + i, (const unsigned char*)src + i + 2, 2); /* Left */
+                memcpy(dst + i + 2, (const unsigned char*)src + i, 2); /* Right */
+            }
+        }
+
+        SDL_UnlockAudio();
+
+        produce_cbuff_data(&sdl_backend->primary_buffer, (size + 3) & ~0x3);
+    }
+    else
+    {
+        DebugMessage(M64MSG_WARNING, "AiLenChanged(): Audio buffer overflow.");
+    }
+}
+
+
+static size_t estimate_level_at_next_audio_cb(struct sdl_backend* sdl_backend)
+{
+    size_t available;
+    unsigned int now = SDL_GetTicks();
+
+    cbuff_tail(&sdl_backend->primary_buffer, &available);
+
+    /* Start by calculating the current Primary buffer fullness in terms of output samples */
+    size_t expected_level = (size_t)(((int64_t)(available/N64_SAMPLE_BYTES) * sdl_backend->output_frequency * 100) / (sdl_backend->input_frequency * sdl_backend->speed_factor));
+
+    /* Next, extrapolate to the buffer level at the expected time of the next audio callback, assuming that the
+       buffer is filled at the same rate as the output frequency */
+    unsigned int expected_next_cb_time = sdl_backend->last_cb_time + ((1000 * sdl_backend->secondary_buffer_size) / sdl_backend->output_frequency);
+
+    if (now < expected_next_cb_time) {
+        expected_level += (expected_next_cb_time - now) * sdl_backend->output_frequency / 1000;
+    }
+
+    return expected_level;
+}
+
+void sdl_synchronize_audio(struct sdl_backend* sdl_backend)
+{
+    enum { TOLERANCE_MS = 10 };
+
+    size_t expected_level = estimate_level_at_next_audio_cb(sdl_backend);
+
+    /* If the expected value of the Primary Buffer Fullness at the time of the next audio callback is more than 10
+       milliseconds ahead of our target buffer fullness level, then insert a delay now */
+    if (sdl_backend->audio_sync && expected_level >= sdl_backend->target + sdl_backend->output_frequency * TOLERANCE_MS / 1000)
+    {
+        /* Core is ahead of SDL audio thread,
+         * delay emulation to allow the SDL audio thread to catch up */
+        unsigned int wait_time = (expected_level - sdl_backend->target) * 1000 / sdl_backend->output_frequency;
+
+        if (sdl_backend->paused_for_sync) { SDL_PauseAudio(0); }
+        sdl_backend->paused_for_sync = 0;
+
+        SDL_Delay(wait_time);
+    }
+    else if (expected_level < sdl_backend->secondary_buffer_size)
+    {
+        /* Core is behind SDL audio thread (predicting an underflow),
+         * pause the audio to let the Core catch up */
+        if (!sdl_backend->paused_for_sync) { SDL_PauseAudio(0); }
+        sdl_backend->paused_for_sync = 1;
+    }
+    else
+    {
+        /* Expected fullness is within tolerance,
+         * audio thread is running */
+        if (sdl_backend->paused_for_sync) { SDL_PauseAudio(0); }
+        sdl_backend->paused_for_sync = 0;
+    }
+}
+
+void sdl_set_speed_factor(struct sdl_backend* sdl_backend, unsigned int speed_factor)
+{
+    if (speed_factor < 10 || speed_factor > 300)
+        return;
+
+    sdl_backend->speed_factor = speed_factor;
+
+    /* we need a different size primary buffer to store the N64 samples when the speed changes */
+    resize_primary_buffer(&sdl_backend->primary_buffer, new_primary_buffer_size(sdl_backend));
+}

--- a/src/sdl_backend.h
+++ b/src/sdl_backend.h
@@ -1,0 +1,41 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-sdl-audio - sdl_backend.h                                 *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2017 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_SDL_BACKEND_H
+#define M64P_SDL_BACKEND_H
+
+#include <stddef.h>
+
+struct sdl_backend;
+
+struct sdl_backend* init_sdl_backend_from_config(m64p_handle config);
+
+void release_sdl_backend(struct sdl_backend* sdl_backend);
+
+void sdl_set_format(struct sdl_backend* sdl_backend, unsigned int frequency, unsigned int bits);
+
+void sdl_push_samples(struct sdl_backend* sdl_backend, const void* src, size_t size);
+
+void sdl_synchronize_audio(struct sdl_backend* sdl_backend);
+
+void sdl_set_speed_factor(struct sdl_backend* sdl_backend, unsigned int speed_factor);
+
+#endif


### PR DESCRIPTION
As a preparatory step toward migrating the audio plugins inside the core, I did some refactorings to ease this migration :
- main module now only contains plugin related stuff (and volume management)
- each resamplers are in a separate module
- sdl audio backend logic is in its own module and mimic the audio_out_backend_interface