### PR TITLE
Remove use of ConfigSaveOptions.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -43,9 +43,7 @@ size_t ResampleAndMix(void* resampler, const struct resampler_interface* iresamp
 extern ptr_ConfigListSections     ConfigListSections;
 extern ptr_ConfigOpenSection      ConfigOpenSection;
 extern ptr_ConfigDeleteSection    ConfigDeleteSection;
-extern ptr_ConfigSaveSection      ConfigSaveSection;
 extern ptr_ConfigListParameters   ConfigListParameters;
-extern ptr_ConfigSaveFile         ConfigSaveFile;
 extern ptr_ConfigSetParameter     ConfigSetParameter;
 extern ptr_ConfigGetParameter     ConfigGetParameter;
 extern ptr_ConfigGetParameterHelp ConfigGetParameterHelp;


### PR DESCRIPTION
Since commit 0bb63fe6f5a in mupen64plus-ui-console, the front-end now
saves the configuration after plugin initialization but before running
the game. Now it is no longer necessary for individual plugins to save
their config.

Removing calls to ConfigSaveOptions from within plugins makes the
'--nosaveoptions' parameter work.

Also remove unused reference to ConfigSaveFile.