### PR TITLE
Fix gcc 8.3 compile with headers for uint32_t

### DIFF
--- a/src/resamplers/speex.c
+++ b/src/resamplers/speex.c
@@ -27,6 +27,7 @@
 #include "m64p_types.h"
 
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #define ARRAY_SIZE(x) sizeof((x)) / sizeof((x)[0])

--- a/src/resamplers/src.c
+++ b/src/resamplers/src.c
@@ -27,6 +27,7 @@
 #include "m64p_types.h"
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
We need to explicitly include `<stdint.h>`