### PR TITLE
build: remove -fno-strict-aliasing

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -99,7 +99,7 @@ OBJDIR = _obj$(POSTFIX)
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I$(SRCDIR)
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fvisibility=hidden -I$(SRCDIR)
 LDFLAGS += $(SHARED)
 
 # Since we are building a shared library, we must compile with -fPIC on some architectures


### PR DESCRIPTION
This builds with -Werror=strict-aliasing so it should be not required.