### PR TITLE
Add header to define memset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@
 #include <SDL_audio.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include "main.h"
 #include "osal_dynamiclib.h"


### PR DESCRIPTION
This becomes necessary when compiling with sdl2-compat for sdl3. Also for strcpy.